### PR TITLE
使用AddMessages代替AddTranslates

### DIFF
--- a/locales/locales.go
+++ b/locales/locales.go
@@ -10,7 +10,7 @@ var Locales = map[string]validate.MS{
 // Register language data to Validation
 func Register(v *validate.Validation, name string) bool {
 	if data, ok := Locales[name]; ok {
-		v.AddTranslates(data)
+		v.AddMessages(data)
 		return true
 	}
 
@@ -31,6 +31,8 @@ var zhCN = map[string]string{
 	"range": "{field} 值必须在此范围内 %d - %d",
 	// required
 	"required": "{field} 是必填项",
+	// email
+	"email": "{field}不是合法邮箱",
 	// field compare
 	"eqField":  "{field} 值必须等于该字段 %s",
 	"neField":  "{field} 值不能等于该字段 %s",

--- a/locales/locales_test.go
+++ b/locales/locales_test.go
@@ -1,9 +1,10 @@
 package locales
 
 import (
+	"testing"
+
 	"github.com/gookit/validate"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestRegister(t *testing.T) {
@@ -15,4 +16,11 @@ func TestRegister(t *testing.T) {
 	ok := Register(v, "zh-CN")
 	is.True(ok)
 	is.False(Register(v, "not-exist"))
+
+	v.AddRule("age", "max", 1)
+	v.AddTranslates(validate.MS{
+		"age": "年龄",
+	})
+	v.Validate()
+	is.Equal(v.Errors.One(), "年龄 的最大值是 1")
 }


### PR DESCRIPTION
本地化包中的`v.AddTranslates` ，应替换为`v.AddMessages`，使用起来会更加友好

根据包中的定义`AddTranslates`用来自定义翻译验证字段名称，而`AddMessages`用来翻译错误信息会比较合适

而目前使用的`AddTranslates`使用后，验证字段名称依然是非本地化语言，如果定义则会覆盖本地化包定义默认错误信息，而换`AddMessages`后，只定义验证字段名称即可，大概意思查看代码