### PR TITLE
EMERGE: Fix panic in custom filter call because of nil variable check.

### DIFF
--- a/filtering_test.go
+++ b/filtering_test.go
@@ -124,3 +124,19 @@ func TestAddFilter(t *testing.T) {
 	is.True(v.IsFail())
 	is.Equal("report a error", v.Errors.Get("_filter"))
 }
+
+// check panic caused nil value with custom filter
+func TestFilterRuleNilValue(t *testing.T) {
+	AddFilter("X", func(in interface{}) interface{} {
+		return in
+	})
+
+	v := Map(map[string]interface{}{
+		"bad": nil,
+	})
+	v.FilterRule("bad", "X")
+
+	assert.NotPanics(t, func() {
+		v.Validate()
+	})
+}

--- a/helper.go
+++ b/helper.go
@@ -11,6 +11,9 @@ import (
 	"github.com/gookit/filter"
 )
 
+// NilObject represent nil value for calling functions and should be reflected at custom filters as nil variable.
+type NilObject struct{}
+
 // CallByValue call func by reflect.Value
 func CallByValue(fv reflect.Value, args ...interface{}) []reflect.Value {
 	if fv.Kind() != reflect.Func {
@@ -19,7 +22,10 @@ func CallByValue(fv reflect.Value, args ...interface{}) []reflect.Value {
 
 	in := make([]reflect.Value, len(args))
 	for k, v := range args {
-		in[k] = reflect.ValueOf(v)
+		// NOTICE: reflect.Call emit panic if kind is Invalid
+		if in[k] = reflect.ValueOf(v); in[k].Kind() == reflect.Invalid {
+			in[k] = reflect.ValueOf(NilObject{})
+		}
 	}
 
 	// NOTICE: CallSlice()与Call() 不一样的是，参数的最后一个会被展开


### PR DESCRIPTION
nil don't has any interface type and any dynamic type or value => reflect.ValueOf(nil).Kind() == reflect.Invalid and reflect.Call with reflect.Invalid parameter emit panic 

This problem very critical as any custom filtered field with nil pulled variable can cause panic recovery of server or even crash of it.

Signed-off-by: d7561985 <d7561985@gmail.com>