### PR TITLE
validation: CheckDefault option whether validate the default value.

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -75,7 +75,9 @@ func (r *Rule) Apply(v *Validation) (stop bool) {
 		}
 
 		// empty value AND skip on empty.
-		if r.skipEmpty && isNotRequired && IsEmpty(val) {
+		// checkDefault assume exist value is valid even it's empty
+		if !(v.CheckDefault && exist) && // is exist in CheckDefault should not skip
+			r.skipEmpty && isNotRequired && IsEmpty(val) {
 			continue
 		}
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -19,6 +19,55 @@ func TestNew(t *testing.T) {
 	assert.True(t, v.Validate())
 }
 
+func TestDefaultOption(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		res  []string
+	}{
+		{"empty", `{}`, []string{"required"}},
+		{"zero set", `{"a":0}`, []string{"min value"}},
+		{"valid value", `{"a":1}`, nil},
+		{"last valid error value", `{"a":1000}`, []string{"max value"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v, err := FromJSON(test.json)
+			assert.NoError(t, err)
+			vld := v.Create()
+			// desired behaviour:
+			// if not set => required
+			// if was provider default int value == 0 => report about min value requirement
+			vld.StringRules(MS{
+				"a": "min:1|required|max:999",
+			})
+			vld.CheckDefault = true
+			vld.SkipOnEmpty = true
+			vld.StopOnError = true
+			_ = vld.Validate()
+			assert.Len(t, vld.Errors, len(test.res))
+			for i := range test.res {
+				assert.Contains(t, vld.Errors.String(), test.res[i])
+			}
+		})
+	}
+}
+
+func TestCheckDefaultOption(t *testing.T) {
+
+	v := New(map[string][]string{
+		"age":  {"12"},
+		"name": {"inhere"},
+	})
+	v.CheckDefault = true
+	v.SkipOnEmpty = true
+	v.StringRules(MS{
+		"age":  "required|strInt",
+		"name": "required|string:3|strLen:4,6",
+	})
+
+	assert.True(t, v.Validate())
+}
 func TestRule_Apply(t *testing.T) {
 	is := assert.New(t)
 	mp := M{

--- a/validation.go
+++ b/validation.go
@@ -67,6 +67,15 @@ type Validation struct {
 	StopOnError bool
 	// SkipOnEmpty Skip check on field not exist or value is empty
 	SkipOnEmpty bool
+	// CheckDefault whether validate the default value
+	// Extend and little constrain SkipOnEmpty option.
+	// Allow provide validation for default type values(bool:false, int:0, string:"") for sending their validation errors
+	// for example:
+	// required|min:1 with StopOnError=false,SkipOnEmpty=true,CheckDefault=true
+	// or min:1|required with StopOnError=false,SkipOnEmpty=true,CheckDefault=true
+	// in case of pulling zero value through JSON, MAP OR REQUEST tell that value should be at least 1 and won't argue
+	// about required case
+	CheckDefault bool
 	// CachingRules switch. default is False
 	// CachingRules bool
 	// mark has error occurs


### PR DESCRIPTION
Extend and little constrain SkipOnEmpty option.
Allow provide validation for default type values(bool:false, int:0, string:"") for sending their validation errors
for example:
	required|min:1 with StopOnError=false,SkipOnEmpty=true,CheckDefault=true
or
	min:1|required with StopOnError=false,SkipOnEmpty=true,CheckDefault=true
in case of pulling zero value through JSON, MAP OR REQUEST tell that value should be at least 1 and won't argue
about required case