### PR TITLE
1.1.x - add requiredXXX validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ filter/aliases | description
 validator/aliases | description
 -------------------|-------------------------------------------
 `required`  | Check value is not empty. 
+`required_if`  | required_if:anotherfield,value,... The field under validation must be present and not empty if the anotherfield field is equal to any value.
+`required_unless`  | required_unless:anotherfield,value,... The field under validation must be present and not empty unless the anotherfield field is equal to any value. 
+`required_with`  | required_with:foo,bar,... The field under validation must be present and not empty only if any of the other specified fields are present.
+`required_with_all`  | required_with_all:foo,bar,... The field under validation must be present and not empty only if all of the other specified fields are present.
+`required_without`  | required_without:foo,bar,... The field under validation must be present and not empty only when any of the other specified fields are not present.
+`required_without_all`  | required_without_all:foo,bar,... The field under validation must be present and not empty only when all of the other specified fields are not present. 
 `-/safe`  | Tag field values ​​are safe and do not require validation
 `int/integer/isInt`  | Check value is `intX` `uintX` type
 `uint/isUint`  |  Check value is uint(`uintX`) type, `value >= 0`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -329,6 +329,12 @@ type GlobalOption struct {
 验证器/别名 | 描述信息
 -------------------|-------------------------------------------
 `required`  | 字段为必填项，值不能为空 
+`required_if`  | required_if:anotherfield,value,...如果其它字段 _anotherfield_ 为任一值 _value_ ，则此验证字段必须存在且不为空。
+`required_unless`  | required_unless:anotherfield,value,...如果其它字段 _anotherfield_ 不等于任一值 _value_ ，则此验证字段必须存在且不为空。 
+`required_with`  | required_with:foo,bar,... 在其他任一指定字段出现时，验证的字段才必须存在且不为空 
+`required_with_all`  | required_with_all:foo,bar,...只有在其他指定字段全部出现时，验证的字段才必须存在且不为空 
+`required_without`  | required_without:foo,bar,...在其他指定任一字段不出现时，验证的字段才必须存在且不为空
+`required_without_all`  | required_without_all:foo,bar,...只有在其他指定字段全部不出现时，验证的字段才必须存在且不为空 
 `-/safe`  | 标记当前字段是安全的，无需验证
 `int/integer/isInt`  | 检查值是 `intX` `uintX` 类型
 `uint/isUint`  |  检查值是 `uintX` 类型（`value >= 0`）

--- a/helper.go
+++ b/helper.go
@@ -55,6 +55,14 @@ func strings2Args(strings []string) []interface{} {
 	return args
 }
 
+func args2strings(args []interface{}) []string {
+	strSlice := make([]string, len(args))
+	for i, s := range args {
+		strSlice[i] = fmt.Sprintf("%v", s)
+	}
+	return strSlice
+}
+
 func buildArgs(val interface{}, args []interface{}) []interface{} {
 	newArgs := make([]interface{}, len(args)+1)
 	newArgs[0] = val

--- a/locales/locales.go
+++ b/locales/locales.go
@@ -30,8 +30,13 @@ var zhCN = map[string]string{
 	"enum":  "{field} 值必须在下列枚举中 %v",
 	"range": "{field} 值必须在此范围内 %d - %d",
 	// required
-	"required":    "{field} 是必填项",
-	"required_if": "当 %v 的值在下列枚举中时 {sArgs}, {field} 是必填项",
+	"required":             "{field} 是必填项",
+	"required_if":          "当  %v 为 {args} 时 {field} 不能为空。",
+	"required_unless":      "当 %v 不为 {args} 时 {field} 不能为空。",
+	"required_with":        "当 {values} 存在时 {field} 不能为空。",
+	"required_with_all":    "当 {values} 存在时 {field} 不能为空。",
+	"required_without":     "当 {values} 不存在时 {field} 不能为空。",
+	"required_without_all": "当 {values} 都不存在时 {field} 不能为空。",
 	// email
 	"email": "{field}不是合法邮箱",
 	// field compare

--- a/locales/locales.go
+++ b/locales/locales.go
@@ -30,7 +30,8 @@ var zhCN = map[string]string{
 	"enum":  "{field} 值必须在下列枚举中 %v",
 	"range": "{field} 值必须在此范围内 %d - %d",
 	// required
-	"required": "{field} 是必填项",
+	"required":    "{field} 是必填项",
+	"required_if": "当 %v 的值在下列枚举中时 {sArgs}, {field} 是必填项",
 	// email
 	"email": "{field}不是合法邮箱",
 	// field compare

--- a/messages.go
+++ b/messages.go
@@ -123,7 +123,13 @@ var defMessages = map[string]string{
 	"enum":  "{field} value must be in the enum %v",
 	"range": "{field} value must be in the range %d - %d",
 	// required
-	"required": "{field} is required",
+	"required":             "{field} is required",
+	"required_if":          "{field} is required when %v is {args}",
+	"required_unless":      "{field} field is required unless %v is in {args}",
+	"required_with":        "{field} field is required when {values} is present",
+	"required_with_all":    "{field} field is required when {values} is present",
+	"required_without":     "{field} field is required when {values} is not present",
+	"required_without_all": "{field} field is required when none of {values} are present",
 	// field compare
 	"eqField":  "{field} value must be equal the field %s",
 	"neField":  "{field} value cannot be equal the field %s",
@@ -225,7 +231,16 @@ func (t *Translator) Message(validator, field string, args ...interface{}) (msg 
 		field = trName
 	}
 
-	return strings.Replace(msg, "{field}", field, 1)
+	values := fmt.Sprintf("%v", args)
+	msg = strings.Replace(msg, "{values}", values, 1)
+	msg = strings.Replace(msg, "{field}", field, 1)
+
+	if len(args) > 0 {
+		args := fmt.Sprintf("%v", args[1:])
+		msg = strings.Replace(msg, "{args}", args, 1)
+	}
+
+	return strings.Split(msg, "%!(EXTRA")[0] //todo gracefully avoid exceptions when formatting strings
 }
 
 // format message for the validator

--- a/validate.go
+++ b/validate.go
@@ -20,6 +20,18 @@ const (
 	statusFail
 )
 
+var (
+	requiredRules = []string{
+		"required",
+		"required_if",
+		"required_unless",
+		"required_with",
+		"required_with_all",
+		"required_without",
+		"required_without_all",
+	}
+)
+
 // Apply current rule for the rule fields
 func (r *Rule) Apply(v *Validation) (stop bool) {
 	// scene name is not match. skip the rule
@@ -30,7 +42,7 @@ func (r *Rule) Apply(v *Validation) (stop bool) {
 	var err error
 	name := ValidatorName(r.validator)
 	// validator name is not "required"
-	isNotRequired := name != "required"
+	isNotRequired := !Enum(name, requiredRules)
 
 	// validate each field
 	for _, field := range r.fields {
@@ -196,6 +208,18 @@ func callValidator(v *Validation, fm *funcMeta, field string, val interface{}, a
 	switch fm.name {
 	case "required":
 		ok = v.Required(field, val)
+	case "required_if":
+		ok = v.RequiredIf(field, val, args2strings(args)...)
+	case "required_unless":
+		ok = v.RequiredUnless(field, val, args2strings(args)...)
+	case "required_with":
+		ok = v.RequiredWith(field, val, args2strings(args)...)
+	case "required_with_all":
+		ok = v.RequiredWithAll(field, val, args2strings(args)...)
+	case "required_without":
+		ok = v.RequiredWithout(field, val, args2strings(args)...)
+	case "required_without_all":
+		ok = v.RequiredWithoutAll(field, val, args2strings(args)...)
 	case "lt":
 		ok = Lt(val, args[0].(int64))
 	case "gt":

--- a/validate_test.go
+++ b/validate_test.go
@@ -35,3 +35,86 @@ func TestRule_Apply(t *testing.T) {
 
 	is.True(v.Validate())
 }
+
+func TestValidation_RequiredIf(t *testing.T) {
+	v := New(M{
+		"age":     "12",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_if:age,12,13,14",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing is required when age is [12 13 14]")
+}
+
+func TestValidation_RequiredUnless(t *testing.T) {
+	v := New(M{
+		"age":     "18",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_unless:age,12,13,14",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing field is required unless age is in [12 13 14]")
+}
+
+func TestValidation_RequiredWith(t *testing.T) {
+	v := New(M{
+		"age":     "18",
+		"name":    "test",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_with:age,name",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing field is required when [age name] is present")
+}
+
+func TestValidation_RequiredWithAll(t *testing.T) {
+	v := New(M{
+		"age":     "18",
+		"name":    "test",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_with:age,name,sex",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing field is required when [age name sex] is present")
+}
+
+
+func TestValidation_RequiredWithout(t *testing.T) {
+	v := New(M{
+		"age":     "18",
+		"name":    "test",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_with:big,sex",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing field is required when [big sex] is present")
+}
+
+func TestValidation_RequiredWithoutAll(t *testing.T) {
+	v := New(M{
+		"age":     "18",
+		"name":    "test",
+		"nothing": "",
+	})
+	v.StringRules(MS{
+		"nothing": "required_with:big,age",
+	})
+
+	v.Validate()
+	assert.Equal(t, v.Errors.One(), "nothing field is required when [big age] is present")
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -38,10 +38,11 @@ func TestRule_Apply(t *testing.T) {
 
 func TestValidation_RequiredIf(t *testing.T) {
 	v := New(M{
-		"age":     "12",
-		"nothing": "",
+		"name": "lee",
+		"age":  "12",
 	})
 	v.StringRules(MS{
+		"age":     "required_if:name,lee",
 		"nothing": "required_if:age,12,13,14",
 	})
 
@@ -52,9 +53,11 @@ func TestValidation_RequiredIf(t *testing.T) {
 func TestValidation_RequiredUnless(t *testing.T) {
 	v := New(M{
 		"age":     "18",
+		"name":    "lee",
 		"nothing": "",
 	})
 	v.StringRules(MS{
+		"age":     "required_unless:name,lee",
 		"nothing": "required_unless:age,12,13,14",
 	})
 
@@ -64,12 +67,13 @@ func TestValidation_RequiredUnless(t *testing.T) {
 
 func TestValidation_RequiredWith(t *testing.T) {
 	v := New(M{
-		"age":     "18",
-		"name":    "test",
-		"nothing": "",
+		"age":  "18",
+		"name": "test",
 	})
 	v.StringRules(MS{
-		"nothing": "required_with:age,name",
+		"age":      "required_with:name,city",
+		"anything": "required_with:sex,city",
+		"nothing":  "required_with:age,name",
 	})
 
 	v.Validate()
@@ -80,29 +84,32 @@ func TestValidation_RequiredWithAll(t *testing.T) {
 	v := New(M{
 		"age":     "18",
 		"name":    "test",
+		"sex":     "man",
 		"nothing": "",
 	})
 	v.StringRules(MS{
-		"nothing": "required_with:age,name,sex",
+		"age":      "required_with:name,sex,city",
+		"anything": "required_with:school,city",
+		"nothing":  "required_with:age,name,sex",
 	})
 
 	v.Validate()
 	assert.Equal(t, v.Errors.One(), "nothing field is required when [age name sex] is present")
 }
 
-
 func TestValidation_RequiredWithout(t *testing.T) {
 	v := New(M{
-		"age":     "18",
-		"name":    "test",
-		"nothing": "",
+		"age":  "18",
+		"name": "test",
 	})
 	v.StringRules(MS{
-		"nothing": "required_with:big,sex",
+		"age":      "required_without:city",
+		"anything": "required_without:age,name",
+		"nothing":  "required_without:sex,name",
 	})
 
 	v.Validate()
-	assert.Equal(t, v.Errors.One(), "nothing field is required when [big sex] is present")
+	assert.Equal(t, v.Errors.One(), "nothing field is required when [sex name] is not present")
 }
 
 func TestValidation_RequiredWithoutAll(t *testing.T) {
@@ -112,9 +119,11 @@ func TestValidation_RequiredWithoutAll(t *testing.T) {
 		"nothing": "",
 	})
 	v.StringRules(MS{
-		"nothing": "required_with:big,age",
+		"age":      "required_without_all:name,city",
+		"anything": "required_without:age,name",
+		"nothing":  "required_without_all:sex,city",
 	})
 
 	v.Validate()
-	assert.Equal(t, v.Errors.One(), "nothing field is required when [big age] is present")
+	assert.Equal(t, v.Errors.One(), "nothing field is required when none of [sex city] are present")
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -88,9 +88,9 @@ func TestValidation_RequiredWithAll(t *testing.T) {
 		"nothing": "",
 	})
 	v.StringRules(MS{
-		"age":      "required_with:name,sex,city",
-		"anything": "required_with:school,city",
-		"nothing":  "required_with:age,name,sex",
+		"age":      "required_with_all:name,sex,city",
+		"anything": "required_with_all:school,city",
+		"nothing":  "required_with_all:age,name,sex",
 	})
 
 	v.Validate()

--- a/validation.go
+++ b/validation.go
@@ -127,7 +127,13 @@ func NewValidation(data DataFace, scene ...string) *Validation {
 
 	// init build in context validator
 	v.validatorValues = map[string]reflect.Value{
-		"required": reflect.ValueOf(v.Required),
+		"required":             reflect.ValueOf(v.Required),
+		"required_if":          reflect.ValueOf(v.RequiredIf),
+		"required_unless":      reflect.ValueOf(v.RequiredUnless),
+		"required_with":        reflect.ValueOf(v.RequiredWith),
+		"required_with_all":    reflect.ValueOf(v.RequiredWithAll),
+		"required_without":     reflect.ValueOf(v.RequiredWithout),
+		"required_without_all": reflect.ValueOf(v.RequiredWithoutAll),
 		// field compare
 		"eqField":  reflect.ValueOf(v.EqField),
 		"neField":  reflect.ValueOf(v.NeField),

--- a/validator_alias.go
+++ b/validator_alias.go
@@ -116,6 +116,13 @@ var validatorAliases = map[string]string{
 	"mimes":     "inMimeTypes",
 	"mimeType":  "inMimeTypes",
 	"mimeTypes": "inMimeTypes",
+	// requiredXXX
+	"requiredIf":         "required_if",
+	"requiredUnless":     "required_unless",
+	"requiredWith":       "required_with",
+	"requiredWithAll":    "required_with_all",
+	"requiredWithout":    "required_without",
+	"requiredWithoutAll": "required_without_all",
 }
 
 // ValidatorName get real validator name.

--- a/validators.go
+++ b/validators.go
@@ -269,7 +269,6 @@ func (v *Validation) Required(field string, val interface{}) bool {
 	return !IsEmpty(val)
 }
 
-// required_if:anotherfield,value,...
 // The field under validation must be present and not empty if the anotherfield field is equal to any value.
 func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) < 2 {
@@ -285,7 +284,6 @@ func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bo
 	return true
 }
 
-// required_unless:anotherfield,value,...
 // The field under validation must be present and not empty unless the anotherfield field is equal to any value.
 func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) < 2 {
@@ -303,7 +301,6 @@ func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string
 	return false
 }
 
-// required_with:foo,bar,...
 // The field under validation must be present and not empty only if any of the other specified fields are present.
 func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
@@ -319,7 +316,6 @@ func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) 
 	return false
 }
 
-// required_with_all:foo,bar,...
 // The field under validation must be present and not empty only if all of the other specified fields are present.
 func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
@@ -335,7 +331,6 @@ func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...strin
 	return NotEqual(val, nil) && NotEqual(val, "")
 }
 
-// required_without:foo,bar,...
 // The field under validation must be present and not empty only when any of the other specified fields are not present.
 func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {

--- a/validators.go
+++ b/validators.go
@@ -269,6 +269,98 @@ func (v *Validation) Required(field string, val interface{}) bool {
 	return !IsEmpty(val)
 }
 
+//required_if:anotherfield,value,...
+//The field under validation must be present and not empty if the anotherfield field is equal to any value.
+func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) < 2 {
+		return false
+	}
+
+	if d, ok := v.Get(kvs[0]); ok {
+		if Enum(d, kvs[1:]) {
+			return NotEqual(val, nil) && NotEqual(val, "")
+		}
+	}
+
+	return true
+}
+
+//required_unless:anotherfield,value,...
+//The field under validation must be present and not empty unless the anotherfield field is equal to any value.
+func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) < 2 {
+		return false
+	}
+
+	if d, ok := v.Get(kvs[0]); ok {
+		if !Enum(d, kvs[1:]) {
+			return NotEqual(val, nil) && NotEqual(val, "")
+		}
+	}
+
+	return false
+}
+
+//The field under validation must be present and not empty only if any of the other specified fields are present.
+func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) == 0 {
+		return false
+	}
+
+	for idx, _ := range kvs {
+		if _, b := v.Get(kvs[idx]); b {
+			return NotEqual(val, nil) && NotEqual(val, "")
+		}
+	}
+
+	return false
+}
+
+//The field under validation must be present and not empty only if all of the other specified fields are present.
+func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) == 0 {
+		return false
+	}
+
+	for idx, _ := range kvs {
+		if _, b := v.Get(kvs[idx]); !b {
+			return false
+		}
+	}
+
+	return NotEqual(val, nil) && NotEqual(val, "")
+}
+
+//The field under validation must be present and not empty only when any of the other specified fields are not present.
+func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) == 0 {
+		return false
+	}
+
+	for idx, _ := range kvs {
+		if _, b := v.Get(kvs[idx]); !b {
+			return NotEqual(val, nil) && NotEqual(val, "")
+		}
+	}
+
+	return false
+}
+
+//The field under validation must be present and not empty only when any of the other specified fields are not present.
+func (v *Validation) RequiredWithoutAll(field string, val interface{}, kvs ...string) bool {
+	if len(kvs) == 0 {
+		return false
+	}
+
+	for idx, _ := range kvs {
+		if _, b := v.Get(kvs[idx]); b {
+			return false
+		}
+	}
+
+	return NotEqual(val, nil) && NotEqual(val, "")
+}
+
 // EqField value should EQ the dst field value
 func (v *Validation) EqField(val interface{}, dstField string) bool {
 	// get dst field value.

--- a/validators.go
+++ b/validators.go
@@ -269,14 +269,17 @@ func (v *Validation) Required(field string, val interface{}) bool {
 	return !IsEmpty(val)
 }
 
-// The field under validation must be present and not empty if the anotherfield field is equal to any value.
+// RequiredIf field under validation must be present and not empty if the anotherfield field is equal to any value.
 func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) < 2 {
 		return false
 	}
 
-	if d, ok := v.Get(kvs[0]); ok {
-		if Enum(d, kvs[1:]) {
+	dstField, args := kvs[0], kvs[1:]
+
+	if dstVal, has := v.Get(dstField); has {
+		if Enum(dstVal, args) {
 			return NotEqual(val, nil) && NotEqual(val, "")
 		}
 	}
@@ -284,8 +287,9 @@ func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bo
 	return true
 }
 
-// The field under validation must be present and not empty unless the anotherfield field is equal to any value.
+// RequiredUnless field under validation must be present and not empty unless the anotherfield field is equal to any value.
 func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) < 2 {
 		return false
 	}
@@ -298,11 +302,13 @@ func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string
 		}
 	}
 
-	return false
+	// fields in values
+	return true
 }
 
-// The field under validation must be present and not empty only if any of the other specified fields are present.
+// RequiredWith field under validation must be present and not empty only if any of the other specified fields are present.
 func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) == 0 {
 		return false
 	}
@@ -313,26 +319,31 @@ func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) 
 		}
 	}
 
-	return false
+	// all fields not exist
+	return true
 }
 
-// The field under validation must be present and not empty only if all of the other specified fields are present.
+// RequiredWithAll field under validation must be present and not empty only if all of the other specified fields are present.
 func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) == 0 {
 		return false
 	}
 
 	for idx := range kvs {
 		if _, has := v.Get(kvs[idx]); !has {
-			return false
+			// if any field does not exist, not continue.
+			return true
 		}
 	}
 
+	// all fields exist
 	return NotEqual(val, nil) && NotEqual(val, "")
 }
 
-// The field under validation must be present and not empty only when any of the other specified fields are not present.
+// RequiredWithout field under validation must be present and not empty only when any of the other specified fields are not present.
 func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) == 0 {
 		return false
 	}
@@ -343,22 +354,25 @@ func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...strin
 		}
 	}
 
-	return false
+	// all fields exist
+	return true
 }
 
-// required_without_all:foo,bar,...
-// The field under validation must be present and not empty only when any of the other specified fields are not present.
+// RequiredWithoutAll field under validation must be present and not empty only when any of the other specified fields are not present.
 func (v *Validation) RequiredWithoutAll(field string, val interface{}, kvs ...string) bool {
+	// format error
 	if len(kvs) == 0 {
 		return false
 	}
 
 	for idx := range kvs {
 		if _, has := v.Get(kvs[idx]); has {
-			return false
+			// if any field exist, not continue.
+			return true
 		}
 	}
 
+	// all fields exist
 	return NotEqual(val, nil) && NotEqual(val, "")
 }
 

--- a/validators.go
+++ b/validators.go
@@ -269,8 +269,8 @@ func (v *Validation) Required(field string, val interface{}) bool {
 	return !IsEmpty(val)
 }
 
-//required_if:anotherfield,value,...
-//The field under validation must be present and not empty if the anotherfield field is equal to any value.
+// required_if:anotherfield,value,...
+// The field under validation must be present and not empty if the anotherfield field is equal to any value.
 func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) < 2 {
 		return false
@@ -285,15 +285,17 @@ func (v *Validation) RequiredIf(field string, val interface{}, kvs ...string) bo
 	return true
 }
 
-//required_unless:anotherfield,value,...
-//The field under validation must be present and not empty unless the anotherfield field is equal to any value.
+// required_unless:anotherfield,value,...
+// The field under validation must be present and not empty unless the anotherfield field is equal to any value.
 func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) < 2 {
 		return false
 	}
 
-	if d, ok := v.Get(kvs[0]); ok {
-		if !Enum(d, kvs[1:]) {
+	dstField, args := kvs[0], kvs[1:]
+
+	if dstVal, has := v.Get(dstField); has {
+		if !Enum(dstVal, args) {
 			return NotEqual(val, nil) && NotEqual(val, "")
 		}
 	}
@@ -301,14 +303,15 @@ func (v *Validation) RequiredUnless(field string, val interface{}, kvs ...string
 	return false
 }
 
-//The field under validation must be present and not empty only if any of the other specified fields are present.
+// required_with:foo,bar,...
+// The field under validation must be present and not empty only if any of the other specified fields are present.
 func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
 		return false
 	}
 
-	for idx, _ := range kvs {
-		if _, b := v.Get(kvs[idx]); b {
+	for idx := range kvs {
+		if _, has := v.Get(kvs[idx]); has {
 			return NotEqual(val, nil) && NotEqual(val, "")
 		}
 	}
@@ -316,14 +319,15 @@ func (v *Validation) RequiredWith(field string, val interface{}, kvs ...string) 
 	return false
 }
 
-//The field under validation must be present and not empty only if all of the other specified fields are present.
+// required_with_all:foo,bar,...
+// The field under validation must be present and not empty only if all of the other specified fields are present.
 func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
 		return false
 	}
 
-	for idx, _ := range kvs {
-		if _, b := v.Get(kvs[idx]); !b {
+	for idx := range kvs {
+		if _, has := v.Get(kvs[idx]); !has {
 			return false
 		}
 	}
@@ -331,14 +335,15 @@ func (v *Validation) RequiredWithAll(field string, val interface{}, kvs ...strin
 	return NotEqual(val, nil) && NotEqual(val, "")
 }
 
-//The field under validation must be present and not empty only when any of the other specified fields are not present.
+// required_without:foo,bar,...
+// The field under validation must be present and not empty only when any of the other specified fields are not present.
 func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
 		return false
 	}
 
-	for idx, _ := range kvs {
-		if _, b := v.Get(kvs[idx]); !b {
+	for idx := range kvs {
+		if _, has := v.Get(kvs[idx]); !has {
 			return NotEqual(val, nil) && NotEqual(val, "")
 		}
 	}
@@ -346,14 +351,15 @@ func (v *Validation) RequiredWithout(field string, val interface{}, kvs ...strin
 	return false
 }
 
-//The field under validation must be present and not empty only when any of the other specified fields are not present.
+// required_without_all:foo,bar,...
+// The field under validation must be present and not empty only when any of the other specified fields are not present.
 func (v *Validation) RequiredWithoutAll(field string, val interface{}, kvs ...string) bool {
 	if len(kvs) == 0 {
 		return false
 	}
 
-	for idx, _ := range kvs {
-		if _, b := v.Get(kvs[idx]); b {
+	for idx := range kvs {
+		if _, has := v.Get(kvs[idx]); has {
 			return false
 		}
 	}

--- a/validators_test.go
+++ b/validators_test.go
@@ -250,9 +250,10 @@ func TestMax(t *testing.T) {
 	is.True(Max(3, 4))
 	is.True(Max(3, 3))
 	is.True(Max(int64(3), 3))
+	// nil will as 0
+	is.True(Max(nil, 3))
 
 	// fail
-	is.False(Max(nil, 3))
 	is.False(Max("str", 3))
 	is.False(Max(3, 2))
 	is.False(Max(int64(3), 2))


### PR DESCRIPTION
添加以下方法：

required_if:anotherfield,value,...
如果其它字段 _anotherfield_ 为任一值 _value_ ，则此验证字段必须存在且不为空。

required_unless:anotherfield,value,...
如果其它字段 _anotherfield_ 不等于任一值 _value_ ，则此验证字段必须存在且不为空。


required_with:foo,bar,...
在其他任一指定字段出现时，验证的字段才必须存在且不为空。


required_with_all:foo,bar,...
只有在其他指定字段全部出现时，验证的字段才必须存在且不为空。


required_without:foo,bar,...
在其他指定任一字段不出现时，验证的字段才必须存在且不为空。


required_without_all:foo,bar,...
只有在其他指定字段全部不出现时，验证的字段才必须存在且不为空。