### PR TITLE
[FIX] FromRequest() JSON content type validation

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"strings"
 )
 
@@ -291,6 +292,8 @@ func FromStruct(s interface{}) (*StructData, error) {
 	return data, nil
 }
 
+var jsonContent = regexp.MustCompile(`(?i)application/((\w|\.|-)+\+)?json(-seq)?`)
+
 // FromRequest collect data from request instance
 func FromRequest(r *http.Request, maxMemoryLimit ...int64) (DataFace, error) {
 	// no body. like GET DELETE ....
@@ -334,7 +337,7 @@ func FromRequest(r *http.Request, maxMemoryLimit ...int64) (DataFace, error) {
 	}
 
 	// JSON body request
-	if strings.Contains(cType, "application/json") {
+	if jsonContent.MatchString(cType) {
 		bs, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem
The [logic](https://github.com/gookit/validate/blob/master/validate.go#L337) to check if a request contains JSON is too restrictive. Since only the exact `application/json` string is considered valid, when the `Content-Type` header contains values such as `application/vnd.api+json` or `application/json; charset=UTF-8`, the request body is dismissed.

Another problem is that there are other JSON MIME types besides `application/json`.

If we do a quick search [here](https://www.iana.org/assignments/media-types/media-types.xhtml), we can find 200+ MIME types related to JSON.

## Solution
The mime type check logic has been improved by using a regular expression. Here's a brief explanation:
```
(?i)  --> case insensitive matches
application/ --> the only type we care about and the type/subtype separator
((\w|\.|-)+\+)? --> this group may exist with one or more (a-z, 0-9, _, . and -) characters and always with a + at the end
json --> the final part of the subtype
(-seq)? --> some JSON MIME types have this suffix
```

## Caveats
The current regular expression isn't strict about the combination of allowed characters in a subtype, which means that non-existent/unofficial MIME types, like `application/foobar+json` or `application/vnd.123+json` are considered valid.

For the sake of simplicity, I think that's a good trade-off. It also means that when new JSON MIME types are added in the future, this logic should require low maintenance, if any.

## Task items:
- [X] Improve JSON Content-Type check logic in `FromRequest()`;
- [X] Update existing tests;