### PR TITLE
improve error message for filter pass-by-value

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -642,7 +642,7 @@ func (d *StructData) Set(field string, val interface{}) (newVal interface{}, err
 
 	// check whether the value of v can be changed.
 	if !fv.CanSet() {
-		return nil, ErrSetValue
+		return nil, ErrUnaddressableField
 	}
 
 	// Notice: need convert value type

--- a/messages.go
+++ b/messages.go
@@ -17,7 +17,7 @@ const defaultErrMsg = " field did not pass validation"
 
 // some internal error definition
 var (
-	ErrUnaddressableField = errors.New("cannot set field as it was not passed-by-reference")
+	ErrUnaddressableField = errors.New("cannot set value as it was not passed-by-reference")
 	ErrNoField  = errors.New("field not exist in the source data")
 
 	ErrEmptyData   = errors.New("please input data use for validate")

--- a/messages.go
+++ b/messages.go
@@ -17,7 +17,7 @@ const defaultErrMsg = " field did not pass validation"
 
 // some internal error definition
 var (
-	ErrSetValue = errors.New("set value failure")
+	ErrUnaddressableField = errors.New("cannot set field as it was not passed-by-reference")
 	ErrNoField  = errors.New("field not exist in the source data")
 
 	ErrEmptyData   = errors.New("please input data use for validate")


### PR DESCRIPTION
I was trying out the filter feature today on a struct, but made a mistake and did not pass the struct by reference/pointer:

```
type Foo struct {
	A string `filter:"trim"`
}

func main() {
	foo := Foo{A: "    test     "}

	v := validate.Struct(foo)
	if !v.Validate() {
		fmt.Println(v.Errors.String())
	}
}
```

It took me a little while to figure out the problem because the error message was not very clear:
```
_filter:
 _filter: set value failure
```

This MR improves the error message to be more informative. Hopefully it helps others debug easier :)