### PR TITLE
add golangci-lint linter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,9 +44,28 @@ jobs:
         flag-name: Go-${{ matrix.go_version }}
         parallel: true
 
+  lint:
+      name: linter
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out code
+          uses: actions/checkout@v3
+
+        - name: Setup Go Faster
+          uses: WillAbides/setup-go-faster@v1.7.0
+          timeout-minutes: 3
+          with:
+            go-version: ${{ matrix.go_version }}
+
+        - name: golangci-lint
+          uses: golangci/golangci-lint-action@v3
+          with:
+            # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+            version: v1.49.0
+
   # notifies that all test jobs are finished.
   finish:
-    needs: test
+    needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,7 +55,7 @@ jobs:
           uses: WillAbides/setup-go-faster@v1.7.0
           timeout-minutes: 3
           with:
-            go-version: ${{ matrix.go_version }}
+            go-version: 1.19
 
         - name: golangci-lint
           uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,48 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errorlint
+    - exportloopref
+    - gocritic
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - grouper
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nilnil
+    - prealloc
+    - predeclared
+    - reassign
+    - revive
+    - staticcheck
+    - stylecheck
+    - tenv
+    - thelper
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+
+linters-settings:
+  gocritic:
+    disabled-checks:
+      - ifElseChain
+      - singleCaseSwitch

--- a/data_source.go
+++ b/data_source.go
@@ -242,6 +242,8 @@ func (d *StructData) Validation(err ...error) *Validation {
 }
 
 // Create from the StructData
+//
+//nolint:forcetypeassert
 func (d *StructData) Create(err ...error) *Validation {
 	v := NewValidation(d)
 	if len(err) > 0 && err[0] != nil {
@@ -401,7 +403,7 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 						switch {
 						case kind == reflect.String:
 							format += "%s"
-							val = strings.ReplaceAll(val.(string), "\"", "")
+							val = strings.ReplaceAll(val.(string), "\"", "") //nolint:forcetypeassert
 						case kind >= reflect.Int && kind <= reflect.Uint64:
 							format += "%d"
 						case kind >= reflect.Float32 && kind <= reflect.Complex128:
@@ -707,9 +709,6 @@ type FormData struct {
 	// need to have more than one file per key, parse the
 	// files manually using r.MultipartForm.File.
 	Files map[string]*multipart.FileHeader
-	// jsonBodies holds the original body of the request.
-	// Only available for json requests.
-	jsonBodies []byte
 }
 
 func newFormData() *FormData {

--- a/filtering.go
+++ b/filtering.go
@@ -68,8 +68,9 @@ func (v *Validation) FilterFuncValue(name string) reflect.Value {
 // FilterRule add filter rule.
 //
 // Usage:
-// 	v.FilterRule("name", "trim|lower")
-// 	v.FilterRule("age", "int")
+//
+//	v.FilterRule("name", "trim|lower")
+//	v.FilterRule("age", "int")
 func (v *Validation) FilterRule(field string, rule string) *FilterRule {
 	rule = strings.TrimSpace(rule)
 	rules := stringSplit(strings.Trim(rule, "|:"), "|")
@@ -119,7 +120,8 @@ func newFilterRule(fields []string) *FilterRule {
 // AddFilters add filter(s).
 //
 // Usage:
-// 	r.AddFilters("int", "str2arr:,")
+//
+//	r.AddFilters("int", "str2arr:,")
 func (r *FilterRule) AddFilters(filters ...string) *FilterRule {
 	for _, filterName := range filters {
 		pos := strings.IndexRune(filterName, ':')
@@ -162,9 +164,6 @@ func (r *FilterRule) Apply(v *Validation) (err error) {
 				v.safeData[field] = newVal // save validated value.
 				continue
 			}
-
-			// go on check custom default value
-			exist = true
 		}
 
 		// call filters

--- a/issues_test.go
+++ b/issues_test.go
@@ -685,10 +685,10 @@ func TestIssues_107(t *testing.T) {
 		if val != nil {
 			// log.WithFields(log.Fields{"value": val}).Info("value should be other than nil")
 			return int64(val.(float64))
-		} else {
-			// log.WithFields(log.Fields{"value": val}).Info("value should be nil")
-			return -1
 		}
+
+		// log.WithFields(log.Fields{"value": val}).Info("value should be nil")
+		return -1
 	}
 
 	v := validate.Map(map[string]interface{}{

--- a/messages.go
+++ b/messages.go
@@ -91,7 +91,7 @@ func (es Errors) All() map[string]map[string]string {
 
 // JSON encode
 func (es Errors) JSON() []byte {
-	bts, _ := json.Marshal(es)
+	bts, _ := json.Marshal(es) //nolint:errchkjson
 	return bts
 }
 

--- a/rule.go
+++ b/rule.go
@@ -21,8 +21,6 @@ type Rule struct {
 	optional bool
 	// skip validate not exist field/empty value
 	skipEmpty bool
-	// default value setting
-	defValue interface{}
 	// error message
 	message string
 	// error messages, if fields contains multi field.

--- a/util.go
+++ b/util.go
@@ -220,6 +220,8 @@ func getVariadicKind(typ reflect.Type) reflect.Kind {
 }
 
 // convTypeByBaseKind convert value type by base kind
+//
+//nolint:forcetypeassert
 func convTypeByBaseKind(srcVal interface{}, srcKind kind, dstType reflect.Kind) (interface{}, error) {
 	switch srcKind {
 	case stringKind:
@@ -391,10 +393,10 @@ func basicKindV2(kind reflect.Kind) (kind, error) {
 		return complexKind, nil
 	case reflect.String:
 		return stringKind, nil
+	default:
+		// like: slice, array, map ...
+		return invalidKind, errBadComparisonType
 	}
-
-	// like: slice, array, map ...
-	return invalidKind, errBadComparisonType
 }
 
 // eq evaluates the comparison a == b

--- a/util_test.go
+++ b/util_test.go
@@ -57,8 +57,7 @@ func TestCallByValue_nil_arg(t *testing.T) {
 	// typ := reflect.TypeOf(interface{}(nil))
 	// typ.Kind()
 
-	var nilV interface{}
-	nilV = 2
+	nilV := 2
 
 	dump.P(
 		reflect.ValueOf(nilV).Kind().String(),

--- a/validate.go
+++ b/validate.go
@@ -2,8 +2,7 @@
 //
 // Source code and other details for the project are available at GitHub:
 //
-// 	https://github.com/gookit/validate
-//
+//	https://github.com/gookit/validate
 package validate
 
 import (
@@ -39,7 +38,7 @@ func (ms MS) String() string {
 		return ""
 	}
 
-	var ss []string
+	ss := make([]string, 0, len(ms))
 	for name, msg := range ms {
 		ss = append(ss, " "+name+": "+msg)
 	}
@@ -391,7 +390,8 @@ func FromURLValues(values url.Values) *FormData {
 // FromQuery build data instance.
 //
 // Usage:
-// 	validate.FromQuery(r.URL.Query()).Create()
+//
+//	validate.FromQuery(r.URL.Query()).Create()
 func FromQuery(values url.Values) *FormData {
 	return FromURLValues(values)
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -34,7 +34,7 @@ func ExampleStruct() {
 		Code      string      `validate:"customValidator|default:abc"`
 		Status    int         `validate:"required|gtField:Extra.0.Status1"`
 		Extra     []ExtraInfo `validate:"required"`
-		protected string
+		protected string      //nolint:unused
 	}
 
 	u := &UserForm{

--- a/validating.go
+++ b/validating.go
@@ -185,7 +185,7 @@ func (r *Rule) fileValidate(field, name string, v *Validation) uint8 {
 		return statusSkip
 	}
 
-	var ss []string
+	ss := make([]string, 0, len(r.arguments))
 	for _, item := range r.arguments {
 		ss = append(ss, item.(string))
 	}

--- a/validation.go
+++ b/validation.go
@@ -115,10 +115,10 @@ func (v *Validation) ResetResult() {
 // Reset the Validation instance.
 //
 // will reset
-// 	- validate result
-// 	- validate rules
-// 	- validate filterRules
-// 	- custom validators
+//   - validate result
+//   - validate rules
+//   - validate filterRules
+//   - custom validators
 func (v *Validation) Reset() {
 	v.ResetResult()
 
@@ -148,11 +148,12 @@ func (v *Validation) WithScenarios(scenes SValues) *Validation {
 // WithScenes set scene config.
 //
 // Usage:
-// 	v.WithScenes(SValues{
-// 		"create": []string{"name", "email"},
-// 		"update": []string{"name"},
-// 	})
-// 	ok := v.AtScene("create").Validate()
+//
+//	v.WithScenes(SValues{
+//		"create": []string{"name", "email"},
+//		"update": []string{"name"},
+//	})
+//	ok := v.AtScene("create").Validate()
 func (v *Validation) WithScenes(scenes map[string][]string) *Validation {
 	v.scenes = scenes
 	return v
@@ -191,7 +192,8 @@ func (v *Validation) AddValidators(m map[string]interface{}) *Validation {
 
 // AddValidator to the Validation. checkFunc must return a bool.
 // Usage:
-// 	v.AddValidator("myFunc", func(val interface{}) bool {
+//
+//	v.AddValidator("myFunc", func(val interface{}) bool {
 //		// do validate val ...
 //		return true
 //	})
@@ -297,10 +299,11 @@ func (v *Validation) Filtering() bool {
 // WithTranslates settings. you can be custom field translates.
 //
 // Usage:
-// 	v.WithTranslates(map[string]string{
-// 		"name": "Username",
-// 		"pwd": "Password",
-//  })
+//
+//		v.WithTranslates(map[string]string{
+//			"name": "Username",
+//			"pwd": "Password",
+//	 })
 func (v *Validation) WithTranslates(m map[string]string) *Validation {
 	v.trans.AddLabelMap(m)
 	return v
@@ -314,11 +317,12 @@ func (v *Validation) AddTranslates(m map[string]string) {
 // WithMessages settings. you can custom validator error messages.
 //
 // Usage:
-// 	// key is "validator" or "field.validator"
-// 	v.WithMessages(map[string]string{
-// 		"require": "oh! {field} is required",
-// 		"range": "oh! {field} must be in the range %d - %d",
-//  })
+//
+//		// key is "validator" or "field.validator"
+//		v.WithMessages(map[string]string{
+//			"require": "oh! {field} is required",
+//			"range": "oh! {field} must be in the range %d - %d",
+//	 })
 func (v *Validation) WithMessages(m map[string]string) *Validation {
 	v.trans.AddMessages(m)
 	return v
@@ -396,9 +400,7 @@ func (v *Validation) tryGet(key string) (val interface{}, exist, zero bool) {
 	}
 
 	// if end withs: .*, return the parent value
-	if strings.HasSuffix(key, ".*") {
-		key = key[0 : len(key)-2]
-	}
+	key = strings.TrimSuffix(key, ".*")
 
 	// find from filtered data.
 	if val, ok := v.filteredData[key]; ok {

--- a/validation_test.go
+++ b/validation_test.go
@@ -359,7 +359,7 @@ func TestValidate_Request(t *testing.T) {
 	is := assert.New(t)
 
 	// =================== GET query data ===================
-	r, _ := http.NewRequest("GET", "/users?page=1&size=10&name= inhere ", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/users?page=1&size=10&name= inhere ", nil)
 	v := Request(r)
 	v.StringRule("page", "required|min:1", "int")
 	// v.StringRule("status", "required|min:1")
@@ -375,7 +375,7 @@ func TestValidate_Request(t *testing.T) {
 
 	// =================== POST: form data ===================
 	body := strings.NewReader("name= inhere &age=50&remember=yes&email=eml@a.com")
-	r, _ = http.NewRequest("POST", "/users", body)
+	r, _ = http.NewRequest(http.MethodPost, "/users", body)
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// create data
 	d, err := FromRequest(r)
@@ -422,7 +422,7 @@ func TestFromRequest_FileForm(t *testing.T) {
 	_ = mw.WriteField("name", "inhere")
 	_ = mw.Close()
 
-	r, _ := http.NewRequest("POST", "/users", buf)
+	r, _ := http.NewRequest(http.MethodPost, "/users", buf)
 	r.Header.Set("Content-Type", mw.FormDataContentType())
 	// - create data
 	d, err := FromRequest(r, defaultMaxMemory)
@@ -548,7 +548,7 @@ func TestFromRequest_JSON(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			is := assert.New(t)
 
-			r, _ := http.NewRequest("POST", "/users", strings.NewReader(test.body))
+			r, _ := http.NewRequest(http.MethodPost, "/users", strings.NewReader(test.body))
 			r.Header.Set("Content-Type", test.header)
 
 			// - create data

--- a/validators.go
+++ b/validators.go
@@ -445,7 +445,7 @@ func (v *Validation) InMimeTypes(fd *FormData, field, mimeType string, moreTypes
 		return false
 	}
 
-	mimeTypes := append(moreTypes, mimeType)
+	mimeTypes := append(moreTypes, mimeType) //nolint:gocritic
 	return Enum(mime, mimeTypes)
 }
 

--- a/validators_test.go
+++ b/validators_test.go
@@ -28,7 +28,7 @@ func TestIsEmpty(t *testing.T) {
 	is.True(ValueIsEmpty(reflect.ValueOf(nil)))
 	is.True(ValueIsEmpty(reflect.ValueOf("")))
 
-	type T struct{ v interface{} }
+	type T struct{ _ interface{} }
 	rv := reflect.ValueOf(T{}).Field(0)
 	is.True(ValueIsEmpty(rv))
 }

--- a/value.go
+++ b/value.go
@@ -25,12 +25,13 @@ func Var(val interface{}, rule string) error {
 // returns error on fail, return nil on check ok.
 //
 // Usage:
-// 	validate.Val("xyz@mail.com", "required|email")
+//
+//	validate.Val("xyz@mail.com", "required|email")
 //
 // refer the Validation.StringRule() for parse rule string.
 func Val(val interface{}, rule string) error {
 	rule = strings.TrimSpace(rule)
-	// input emtpy rule, skip validate
+	// input empty rule, skip validate
 	if rule == "" {
 		return nil
 	}


### PR DESCRIPTION
Add golangci-lint linter with github action

Not many changes :) 

Some unused/ineffectual code, and some slice preallocation optimisations.

Sorry that lots of the comments got reformatted, I think this is because of [new Go 1.19 docstrings](https://tip.golang.org/doc/comment). 