### PR TITLE
feat: enable slices of maps on structs

### DIFF
--- a/validating.go
+++ b/validating.go
@@ -252,7 +252,8 @@ func (r *Rule) valueValidate(field, name string, val interface{}, v *Validation)
 	valKind := rftVal.Kind()
 
 	// feat: support check sub element in a slice list. eg: field=names.*
-	if valKind == reflect.Slice && strings.HasSuffix(field, ".*") {
+	hasSliceSuffix := len(strings.Split(field, ".*")) > 1
+	if valKind == reflect.Slice && hasSliceSuffix {
 		var subVal interface{}
 		for i := 0; i < rftVal.Len(); i++ {
 			subRv := rftVal.Index(i)

--- a/validation.go
+++ b/validation.go
@@ -398,7 +398,10 @@ func (v *Validation) tryGet(key string) (val interface{}, exist, zero bool) {
 	if v.data == nil {
 		return
 	}
-
+	vals := strings.Split(key, ".*")
+	if len(vals) > 1 {
+		key = vals[0]
+	}
 	// if end withs: .*, return the parent value
 	key = strings.TrimSuffix(key, ".*")
 
@@ -503,11 +506,7 @@ func (v *Validation) Set(field string, val interface{}) error {
 func (v *Validation) updateValue(field string, val interface{}) (interface{}, error) {
 	// data source is struct
 	if v.data.Type() == sourceStruct {
-		// if end withs: .*, trim suffix
-		if strings.HasSuffix(field, ".*") {
-			field = field[0 : len(field)-2]
-		}
-		return v.data.Set(field, val)
+		return v.data.Set(strings.TrimSuffix(field, ".*"), val)
 	}
 
 	// TODO dont update value for Form and Map data source


### PR DESCRIPTION
Right now, the system only allows to  use `tags.*` for slices, but if the slice is a complex type(struct or map) there is no way to validate.

This commits adds a way to test inside slice content if the value is a map:

```
var data = map[string]interface{}{
  "user": "foo",
  "properties": []map[string]string{{
    "phone": "12001",
    "alias": "foobar",
  }},
}

v := validate.Map(data)

v.ConfigRules(map[string]string{
  "properties.*.phone": "int",
  "properties.*.alias": "minlen:4",
})
```

Added tests inside a current test, I thought that makes sense to have in there.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>