### PR TITLE
fix: validation for embedded structs

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -297,7 +297,6 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 	// preStrName - the parent field name.
 	recursiveFunc = func(vv reflect.Value, vt reflect.Type, parentFName string, parentIsAnonymous bool) {
 		for i := 0; i < vt.NumField(); i++ {
-			fValue := removeValuePtr(vv).Field(i)
 			fv := vt.Field(i)
 			// skip don't exported field
 			name := fv.Name
@@ -365,15 +364,14 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 			ft := removeTypePtr(vt.Field(i).Type)
 
 			// collect rules from sub-struct and from arrays/slices elements
-			if ft != timeType {
-				if fValue.Type().Kind() == reflect.Ptr && fValue.IsNil() {
-					continue
-				}
+			if ft != timeType && removeValuePtr(vv).IsValid() {
 
 				// feat: only collect sub-struct rule on current field has rule.
 				if vRule == "" && gOpt.CheckSubOnParentMarked {
 					continue
 				}
+
+				fValue := removeValuePtr(vv).Field(i)
 
 				switch ft.Kind() {
 				case reflect.Struct:

--- a/validation.go
+++ b/validation.go
@@ -591,6 +591,14 @@ func (v *Validation) isNotNeedToCheck(field string) bool {
 		return false
 	}
 
+	fields := strings.Split(field, ".")
+	for i := 0; i < len(fields); i++ {
+		_, ok := v.sceneFields[strings.Join(fields[0:i], ".")]
+		if ok {
+			return false
+		}
+	}
+
 	_, ok := v.sceneFields[field]
 	return !ok
 }


### PR DESCRIPTION
This fixes https://github.com/gookit/validate/issues/188 

1. Fix the fact that embedded struct pointers were not validated. 
* This was because of the `if fValue.Type().Kind() == reflect.Ptr && fValue.IsNil()` skip
* To make this work, a different check `removeValuePtr(vv).IsValid()` is used.
2. Allow scenes field rules to apply to child fields.

For example, in my test case, I can add `Settings.Pet` for a validator scene, and it will apply the rules for `Settings.Pet.Breed` and `Settings.Pet.Color`, so I do not have to list every single field.