### PR TITLE
Improve validation of pointer fields

### DIFF
--- a/validating.go
+++ b/validating.go
@@ -347,6 +347,17 @@ func (r *Rule) valueValidate(field, name string, val any, v *Validation) (ok boo
 
 // convert input field value type, is validator func first argument.
 func convValAsFuncArg0Type(arg0Kind, valKind reflect.Kind, val any) (any, bool) {
+	// If the validator function does not expect a pointer, but the value is a pointer,
+	// dereference the value.
+	if arg0Kind != reflect.Ptr && valKind == reflect.Ptr {
+		if val == nil {
+			return nil, true
+		}
+
+		val = reflect.ValueOf(val).Elem().Interface()
+		valKind = reflect.TypeOf(val).Kind()
+	}
+
 	// ak, err := basicKind(rftVal)
 	bk, err := basicKindV2(valKind)
 	if err != nil {


### PR DESCRIPTION
Enhanced the validation logic to handle pointer fields more robustly. Previously, the validation would fail when a field was a pointer type but the validation function expected a non-pointer type. The changes include dereferencing the pointer before validation if the validation function does not expect a pointer, and adding a nil check before dereferencing. This makes the validation logic more robust and flexible, allowing for better handling of pointer and non-pointer fields.

Fix #236 
