### PR TITLE
Fix: Prevent panic when validating struct with nil pointer to map field

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -384,7 +384,7 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 					fValue = removeValuePtr(fValue)
 
 					// Check if the reflect.Value is valid and not a nil pointer
-					if !fValue.IsValid() {
+					if !fValue.IsValid() || fValue.IsNil() {
 						continue
 					}
 
@@ -400,6 +400,12 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 
 				case reflect.Map:
 					fValue = removeValuePtr(fValue)
+
+					// Check if the reflect.Value is valid and not a nil pointer
+					if !fValue.IsValid() || fValue.IsNil() {
+						continue
+					}
+
 					for _, key := range fValue.MapKeys() {
 						key = removeValuePtr(key)
 						elemValue := removeValuePtr(fValue.MapIndex(key))


### PR DESCRIPTION
This pull request addresses a issue within the `gookit/validate` library where attempting to validate a struct containing a nil pointer to a map field results in a runtime panic.

**Problem:**
The library encounters a panic with the error message: `reflect: call of reflect.Value.MapKeys on zero Value`, when it attempts to validate a struct field that is a nil pointer to a map. This occurs due to the invocation of `MapKeys()` without prior validation of the `reflect.Value` being both non-nil and valid.

**Solution:**
A safeguard has been implemented to check that the `reflect.Value` is not nil and is valid before any call to `MapKeys()`. This modification ensures graceful handling of nil pointer fields, treating them as empty maps, which is the anticipated behavior for such cases in the validation process.

**Example Reproduction and Fix Verification:**

The issue and the effectiveness of the proposed fix can be demonstrated with the following example:

```go
package main

import (
    "github.com/gookit/validate"
    "github.com/stretchr/testify/assert"
)

type TagRequest struct {
    Metadata *map[string]interface{} `validate:"required"`
}

func main() {
    data := &TagRequest{}
    v := validate.Struct(data)

    ok := v.Validate() // Prior to the fix, this call would panic
    assert.False(t, ok) // The assertion is expected to be false since Metadata is required but nil
}
```

With the implementation of the proposed fix, the `Validate` method now appropriately interprets the nil pointer to the map as an empty map. Consequently, the validation process proceeds without a panic, and the assertion evaluates as intended, reflecting the non-fulfillment of the `required` rule for the `Metadata` field due to its nil value.

This enhancement not only prevents undesirable application crashes but also aligns the library's behavior with the conventional handling of nil pointers in Go, thereby improving its reliability and usability.