### PR TITLE
[Doc] Add code example of how to use custom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,8 @@ func main() {
 			return 1, nil
 		},
 	})
+	// use the added filter
+	v.FilterRule("field", "myToIntFilter0")
 }
 ```
 

--- a/_examples/httpdemo2/main.go
+++ b/_examples/httpdemo2/main.go
@@ -40,8 +40,7 @@ func main() {
 		v := data.Create()
 		// setting rules
 		v.
-			// StringRule("categoryId", "required|int|min:1", "newIsInt").
-			StringRule("categoryId", "required|int|min:1", "toInt").
+			StringRule("categoryId", "required|int|min:1", "newIsInt").
 			AddMessages(map[string]string{
 				"required": "the {field} is required",
 				"min":      "{field} min value is %d",


### PR DESCRIPTION
## Description

Yesterday I tried to use a custom filter but couldn't get it to work. I looked in the documentation and example code but found no information about this, so I read the source code and figured out that I had to call the `FilterRule` method. Upon reflection, this design makes sense and feels natural but I think it would be good to have an example in the readme.

## Changes Made

1. Add a `FilterRule` call in the readme's `Add Custom Filter` section.
2. Uncomment a line in the example code, making the usage of the custom filter more obvious.
