### PR TITLE
feat: support validation of array values in URL query parameters

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -841,7 +841,11 @@ func (d FormData) TryGet(key string) (val any, exist, zero bool) {
 // Get value by key
 func (d FormData) Get(key string) (any, bool) {
 	// get form value
+	key, _, _ = strings.Cut(key, ".*")
 	if vs, ok := d.Form[key]; ok && len(vs) > 0 {
+		if len(vs) > 1 {
+			return vs, true
+		}
 		return vs[0], true
 	}
 

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -57,6 +57,7 @@ func TestFormData(t *testing.T) {
 		"age":    {"30"},
 		"notify": {"true"},
 		"money":  {"23.4"},
+		"emails": {"some@email.com", "other@email.com"},
 	})
 
 	is.True(d.Has("notify"))
@@ -74,7 +75,8 @@ func TestFormData(t *testing.T) {
 	is.Equal(23.4, d.Float("money"))
 	is.Equal(float64(0), d.Float("not-exist"))
 	is.Equal("inhere", d.String("name"))
-	is.Equal("age=30&money=23.4&name=inhere&notify=true", d.Encode())
+	is.Equal([]string{"some@email.com", "other@email.com"}, d.Strings("emails"))
+	is.Equal("age=30&emails=some%40email.com&emails=other%40email.com&money=23.4&name=inhere&notify=true", d.Encode())
 
 	val, exist, zero := d.TryGet("name")
 	is.True(exist)
@@ -84,6 +86,11 @@ func TestFormData(t *testing.T) {
 	val, exist = d.Get("name")
 	is.True(exist)
 	is.Equal("inhere", val)
+
+	emails, exist := d.Get("emails")
+	is.True(exist)
+	is.Len(emails, 2)
+	is.Equal([]string{"some@email.com", "other@email.com"}, emails)
 
 	nval, err := d.Set("newKey", "strVal")
 	is.NoErr(err)

--- a/validators.go
+++ b/validators.go
@@ -1198,8 +1198,8 @@ func StringLength(val any, minLen int, maxLen ...int) bool {
  *************************************************************/
 
 // IsDate check value is an date string.
-func IsDate(srcDate string) bool {
-	_, err := strutil.ToTime(srcDate)
+func IsDate(srcDate string, layouts ...string) bool {
+	_, err := strutil.ToTime(srcDate, layouts...)
 	return err == nil
 }
 

--- a/validators_test.go
+++ b/validators_test.go
@@ -725,6 +725,7 @@ func TestDateCheck(t *testing.T) {
 	is := assert.New(t)
 	// Date
 	is.True(IsDate("2018-10-25"))
+	is.True(IsDate("2018-10", "2006-01"))
 
 	// DateFormat
 	is.True(DateFormat("2018-10-25", "2006-01-02"))


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/286

```go
v := validate.New(map[string][]string{
	"date": {"2023-03", "2023-04"},
})

v.StringRule("date", "required|array|len:2")
v.StringRule("date.*", "required|date:2006-01")

if v.Validate() {
	fmt.Println(v.SafeData())
} else {
	fmt.Println(v.Errors)
}
```

Print:

```bash
map[date:[2023-03 2023-04] date.*:[2023-03 2023-04]]
```