### PR TITLE
feat: support multi multipart.FileHeader binding

### DIFF
--- a/data_source_test.go
+++ b/data_source_test.go
@@ -127,6 +127,7 @@ func TestFormData(t *testing.T) {
 	d.AddFiles(map[string][]*multipart.FileHeader{"files": {&multipart.FileHeader{Filename: "test1.txt"}, &multipart.FileHeader{Filename: "test2.txt"}}})
 	is.True(d.Has("files"))
 	is.True(d.HasFile("files"))
+	is.True(d.HasFile("files.*"))
 	is.Len(d.GetFiles("files"), 2)
 	d.DelFile("files")
 	is.False(d.HasFile("files"))

--- a/validating.go
+++ b/validating.go
@@ -173,6 +173,9 @@ func (r *Rule) Apply(v *Validation) (stop bool) {
 
 		// validate field value
 		if r.valueValidate(field, name, val, v) {
+			if v.data != nil && v.data.Type() == sourceForm {
+				field, _, _ = strings.Cut(field, ".*")
+			}
 			v.safeData[field] = val
 		} else { // build and collect error message
 			v.AddError(field, r.validator, r.errorMessage(field, r.validator, v))


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/290

```go
type UserForm struct {
	Name   string
	File   *multipart.FileHeader
	Images []*multipart.FileHeader
	Docs   []*multipart.FileHeader
}

data, err := validate.FromRequest(ctx.Request().Origin())
if err != nil {
	panic(err)
}

v := data.Create()
v.AddRule("name", "required")
// add a non-file rule (e.g. required), otherwise the field won’t be included in safeData and BindSafeData will be ignored.
v.AddRule("file", "required")
v.AddRule("file", "file")
v.AddRule("images.*", "required")
v.AddRule("images.*", "image", "jpg", "jpeg")
v.AddRule("images.*", "mimeTypes", "image/jpeg")
v.AddRule("docs.*", "required")
v.AddRule("docs.*", "file")
v.AddRule("docs.*", "mime", "text/plain", "application/pdf")

if v.Validate() { // validate ok
	// safeData := v.SafeData()
	userForm := &UserForm{}
	if err := v.BindSafeData(userForm); err != nil {
		panic(err)
	}

	// do something ...
	fmt.Println("Single file:", userForm.File.Filename)
	for k, v := range userForm.Images {
		fmt.Println("Image", k, ":", v.Filename)
	}
	for k, v := range userForm.Docs {
		fmt.Println("Doc", k, ":", v.Filename)
	}
} else {
	fmt.Println(v.Errors)       // all error messages
	fmt.Println(v.Errors.One()) // returns a random error message text
}
```

```bash
curl --location 'http://127.0.0.1:3000/files' \
--form 'name="test"' \
--form 'file=@"/tmp/start.sh"' \
--form 'images=@"/tmp/mountain-cloud.jpg"' \
--form 'Docs=@"/tmp/test.txt"' \
--form 'Docs=@"/tmp/test.pdf"'
```

Print:

```bash
Single file: start.sh
Image 0 : mountain-cloud.jpg
Doc 0 : test.txt
Doc 1 : test.pdf
```
