### PR TITLE
Fix: prevent panic when using named string types as map keys

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -407,7 +407,7 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 						switch {
 						case kind == reflect.String:
 							format += "%s"
-							val = strings.ReplaceAll(val.(string), "\"", "") //nolint:forcetypeassert
+							val = strings.ReplaceAll(key.String(), "\"", "")
 						case kind >= reflect.Int && kind <= reflect.Uint64:
 							format += "%d"
 						case kind >= reflect.Float32 && kind <= reflect.Complex128:

--- a/data_source_test.go
+++ b/data_source_test.go
@@ -153,6 +153,9 @@ func TestStructData_Create(t *testing.T) {
 		Extra: []ExtraInfo{
 			{"xxx", 2},
 		},
+		CustomString: map[CustomString]string{
+			"custom": "str",
+		},
 	}
 
 	d, err := FromStruct(u)

--- a/validation_test.go
+++ b/validation_test.go
@@ -150,15 +150,16 @@ func TestErrorMessages(t *testing.T) {
 
 // UserForm struct
 type UserForm struct {
-	Name      string      `validate:"required|minLen:7"`
-	Email     string      `validate:"email"`
-	CreateAt  int         `validate:"email"`
-	Safe      int         `validate:"-"`
-	UpdateAt  time.Time   `validate:"required"`
-	Code      string      `validate:"customValidator"`
-	Status    int         `validate:"required|gtField:Extra.0.Status1"`
-	Extra     []ExtraInfo `validate:"required"`
-	protected string
+	Name         string                  `validate:"required|minLen:7"`
+	Email        string                  `validate:"email"`
+	CreateAt     int                     `validate:"email"`
+	Safe         int                     `validate:"-"`
+	UpdateAt     time.Time               `validate:"required"`
+	Code         string                  `validate:"customValidator"`
+	Status       int                     `validate:"required|gtField:Extra.0.Status1"`
+	Extra        []ExtraInfo             `validate:"required"`
+	CustomString map[CustomString]string `validate:"-"`
+	protected    string
 }
 
 // ExtraInfo data
@@ -166,6 +167,9 @@ type ExtraInfo struct {
 	Github  string `validate:"required|url"` // tags is invalid
 	Status1 int    `validate:"required|int"`
 }
+
+// CustomString is a named string type
+type CustomString string
 
 // custom validator in the source struct.
 func (f UserForm) CustomValidator(val string) bool {


### PR DESCRIPTION
In reflection-based validation we were force‑casting map values to string, which panicked if the key wasn’t a raw string but a named string:

`val = strings.ReplaceAll(val.(string), "\"", "") //nolint:forcetypeassert`

By switching to `key.String()`, we obtain the textual form of any named string key without a type assertion.