### PR TITLE
feat: add option to restore request body after reading

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -6,6 +6,7 @@
 package validate
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -106,6 +107,10 @@ type GlobalOption struct {
 	//
 	// default: false
 	ValidatePrivateFields bool
+
+	// RestoreRequestBody Whether to restore the request body after reading it.
+	// default: false
+	RestoreRequestBody bool
 }
 
 // global options
@@ -395,6 +400,10 @@ func FromRequest(r *http.Request, maxMemoryLimit ...int64) (DataFace, error) {
 		bs, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err
+		}
+		// restore request body
+		if gOpt.RestoreRequestBody {
+			r.Body = io.NopCloser(bytes.NewBuffer(bs))
 		}
 		return FromJSONBytes(bs)
 	}


### PR DESCRIPTION
This pull request introduces a new global option to control whether the HTTP request body should be automatically restored after being read. This enhancement increases the flexibility of the validation process by allowing users to enable or disable request body restoration, ensuring that the body remains available for further processing by subsequent middleware or handlers.

**Key Changes:**
- Adds a configurable global option for restoring the request body after validation.
- Improves compatibility with middleware and custom logic that may require access to the original request body.
- Provides users with fine-grained control over request lifecycle management.

This update addresses [goravel/goravel Issue #334](https://github.com/goravel/goravel/issues/334).