### PR TITLE
fix: support validation of google/uuid.UUID type

### DIFF
--- a/util.go
+++ b/util.go
@@ -258,7 +258,7 @@ func getVariadicKind(typ reflect.Type) reflect.Kind {
 // convTypeByBaseKind convert value type by base kind
 //
 //nolint:forcetypeassert
-func convTypeByBaseKind(srcVal any, _ kind, dstType reflect.Kind) (any, error) {
+func convTypeByBaseKind(srcVal any, dstType reflect.Kind) (any, error) {
 	rv, err := reflects.ConvToKind(srcVal, dstType)
 	if err != nil {
 		return nil, err

--- a/validate_test.go
+++ b/validate_test.go
@@ -111,11 +111,26 @@ func TestUtil_Func_goodName(t *testing.T) {
 }
 
 func Test_Util_Func_convertType(t *testing.T) {
-	nVal, err := convTypeByBaseKind(23, intKind, reflect.String)
+	nVal, err := convTypeByBaseKind(23, reflect.String)
 	assert.NoError(t, err)
 	assert.Equal(t, "23", nVal)
 
-	nVal, err = convTypeByBaseKind(uint(23), uintKind, reflect.String)
+	nVal, err = convTypeByBaseKind(uint(23), reflect.String)
+	assert.NoError(t, err)
+	assert.Equal(t, "23", nVal)
+
+	nVal, err = convTypeByBaseKind([]byte("23"), reflect.String)
+	assert.NoError(t, err)
+	assert.Equal(t, "23", nVal)
+
+	nVal, err = convTypeByBaseKind("23", reflect.Int)
+	assert.NoError(t, err)
+	assert.Equal(t, 23, nVal)
+
+	// Stringer convert to string
+	var val strings.Builder
+	val.WriteString("23")
+	nVal, err = convTypeByBaseKind(&val, reflect.String)
 	assert.NoError(t, err)
 	assert.Equal(t, "23", nVal)
 }

--- a/validators.go
+++ b/validators.go
@@ -208,7 +208,7 @@ func (v *Validation) RequiredIf(_ string, val any, kvs ...string) bool {
 		// up: only one check value, direct compare value
 		if len(args) == 1 {
 			rftDv := reflect.ValueOf(dstVal)
-			wantVal, err := convTypeByBaseKind(args[0], stringKind, rftDv.Kind())
+			wantVal, err := convTypeByBaseKind(args[0], rftDv.Kind())
 			if err == nil && dstVal == wantVal {
 				return val != nil && !IsEmpty(val)
 			}


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/294

This change unifies all type conversions for validation arguments through `convTypeByBaseKind`, leveraging `reflects.ConvToKind` internally.
As a result, custom types—including `github.com/google/uuid.UUID`—are now correctly coerced to string when they implement `fmt.Stringer`.
This allows the uuid validator to validate google/uuid.UUID fields without error, resolving issue #294.