### PR TITLE
fix: preserve nested JSON tag paths in error keys

### DIFF
--- a/data_source.go
+++ b/data_source.go
@@ -383,6 +383,9 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 						elemType := removeTypePtr(elemValue.Type())
 
 						arrayName := fmt.Sprintf("%s.%d", name, j)
+						if outName != "" {
+							fOutMap[arrayName] = fmt.Sprintf("%s.%d", outName, j)
+						}
 						if elemType.Kind() == reflect.Struct {
 							recursiveFunc(elemValue, elemType, arrayName, fv.Anonymous)
 						}
@@ -417,6 +420,9 @@ func (d *StructData) parseRulesFromTag(v *Validation) {
 						}
 
 						arrayName := fmt.Sprintf(format, name, val)
+						if outName != "" {
+							fOutMap[arrayName] = fmt.Sprintf(format, outName, val)
+						}
 						if elemType.Kind() == reflect.Struct {
 							recursiveFunc(elemValue, elemType, arrayName, fv.Anonymous)
 						}


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/297
close https://github.com/gookit/validate/issues/282

- Error keys now correctly use full JSON tag paths in nested arrays and structs.
- Resolves issue where error keys were missing JSON tags, e.g., "extras.0.github" instead of "github".