### PR TITLE
fix: resolve eqField validation for pointer types in the validator

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -1847,3 +1847,32 @@ func TestIssue_297(t *testing.T) {
 	}
 	assert.Equal(t, "extras.0.github", firstKeyJSON)
 }
+
+// http://github.com/gookit/validate/issues/272 eqField does not correctly validate pointer type data
+func TestIssue_272(t *testing.T) {
+	type Test struct {
+		FieldA *string `validate:"required"`
+		FieldB *string `validate:"eqField:FieldA"`
+	}
+
+	var (
+		fieldA = "A"
+		fieldB = "B"
+	)
+	t.Run("equal", func(t *testing.T) {
+		v := validate.Struct(Test{
+			FieldA: &fieldA,
+			FieldB: &fieldA,
+		})
+		assert.True(t, v.Validate())
+	})
+
+	t.Run("not equal", func(t *testing.T) {
+		v := validate.Struct(Test{
+			FieldA: &fieldA,
+			FieldB: &fieldB,
+		})
+		assert.False(t, v.Validate())
+		assert.Equal(t, "FieldB value must be equal the field FieldA", v.Errors.One())
+	})
+}

--- a/validators.go
+++ b/validators.go
@@ -1036,8 +1036,8 @@ func IsEqual(val, wantVal any) bool {
 		return val == wantVal
 	}
 
-	sv := reflect.ValueOf(val)
-	wv := reflect.ValueOf(wantVal)
+	sv := removeValuePtr(reflect.ValueOf(val))
+	wv := removeValuePtr(reflect.ValueOf(wantVal))
 
 	// don't compare func, struct
 	if sv.Kind() == reflect.Func || sv.Kind() == reflect.Struct {


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/272

This PR resolves an issue where the eqField validation rule did not properly handle pointer types in structs. Previously, when comparing fields like `FieldA *string` and` FieldB *string` using` eqField:FieldA`, the validator would fail to correctly assess equality if both fields were pointers.

With this fix, `eqField` now correctly dereferences pointer values and compares their actual contents, ensuring accurate validation for pointer fields.