### PR TITLE
fix: required rule fails for int/uint values equal to 0

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -601,7 +601,7 @@ func TestIssues_I36T2B(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, "a value should be greater than 100", v.Errors.One())
 
-	v = validate.Map(m)
+	v = validate.Map(make(map[string]any))
 	v.AddRule("a", "required")
 	v.AddRule("a", "gt", 100)
 
@@ -1875,4 +1875,28 @@ func TestIssue_272(t *testing.T) {
 		assert.False(t, v.Validate())
 		assert.Equal(t, "FieldB value must be equal the field FieldA", v.Errors.One())
 	})
+}
+
+// http://github.com/gookit/validate/issues/302 The required rule fails for int/uint values when the value is 0.
+func TestIssue_302(t *testing.T) {
+	v := validate.Map(map[string]any{
+		"required":             0,
+		"required_if":          0,
+		"required_unless":      0,
+		"required_with":        0,
+		"required_with_all":    0,
+		"required_without":     0,
+		"required_without_all": 0,
+	})
+	v.StringRules(map[string]string{
+		"required":             "required|uint|in:0,1,2",
+		"required_if":          "required_if:required,0",
+		"required_unless":      "required_unless:required,1",
+		"required_with":        "required_with:required",
+		"required_with_all":    "required_with_all:required,required_if",
+		"required_without":     "required_without:nonexist",
+		"required_without_all": "required_without_all:nonexist,required",
+	})
+	assert.True(t, v.Validate())
+	assert.Empty(t, v.Errors.One())
 }


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/302

This PR addresses an issue with the validation of required rules for numeric fields, specifically ensuring that zero values for int/uint types are handled correctly as valid input in certain required scenarios. The main changes involve updating the logic of required-related validation methods and adding a new helper to identify zero numeric values that should be considered valid.

**Validation logic improvements for numeric zero values:**

* Added a new helper method `isIgnoreableZeroNumeric` to the `Validation` struct to detect if a field is a numeric type with a zero value, allowing such values to be considered valid for required rules.
* Updated the `Required`, `RequiredIf`, `RequiredUnless`, `RequiredWith`, `RequiredWithAll`, `RequiredWithout`, and `RequiredWithoutAll` methods to use `isIgnoreableZeroNumeric`, ensuring that zero values for numeric types are not incorrectly treated as missing or empty. [[1]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0R191-R194) [[2]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L201-R205) [[3]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L213-R220) [[4]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L228-R240) [[5]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L248-R259) [[6]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L264-R268) [[7]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L277-R292) [[8]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L297-R301) [[9]](diffhunk://#diff-325266957835be5172e500da7f09b20b49b6894a2c10952b50ca693126f22eb0L310-R314)

**Testing enhancements:**

* Added a new test case `TestIssue_302` to verify that required rules correctly accept zero values for int/uint fields, preventing regression on this behavior.
* Minor adjustment in `TestIssues_I36T2B` to ensure a fresh map is used in validation, improving test reliability.