### PR TITLE
fix: support escaped "|" in regex validation rules

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -1880,11 +1880,15 @@ func TestIssue_272(t *testing.T) {
 // http://github.com/gookit/validate/issues/301 Regex pipe escape
 func TestIssue_301(t *testing.T) {
 	v := validate.Map(map[string]any{
-		"field": "abc.json",
-		"other": "123",
+		"field":   "abc.json",
+		"other":   "123",
+		"escape":  "a|b",
+		"escape2": "a\\|b",
 	})
 	v.StringRule("field", "required|regex:^[a-zA-Z0-9_.-]+\\.(yaml\\|yml\\|json)$|maxLen:50")
 	v.StringRule("other", "required|regex:^\\d{3}$")
+	v.StringRule("escape", "in: a\\|b")
+	v.StringRule("escape2", "in: a\\\\|b")
 	assert.True(t, v.Validate())
 }
 

--- a/issues_test.go
+++ b/issues_test.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"github.com/gookit/goutil"
-	"github.com/gookit/goutil/maputil"
-	"github.com/gookit/goutil/timex"
-	"github.com/gookit/validate/locales/zhcn"
-
 	"github.com/gookit/goutil/dump"
 	"github.com/gookit/goutil/jsonutil"
+	"github.com/gookit/goutil/maputil"
 	"github.com/gookit/goutil/testutil/assert"
+	"github.com/gookit/goutil/timex"
+
 	"github.com/gookit/validate"
+	"github.com/gookit/validate/locales/zhcn"
 )
 
 func TestIssue_2(t *testing.T) {
@@ -1875,6 +1875,17 @@ func TestIssue_272(t *testing.T) {
 		assert.False(t, v.Validate())
 		assert.Equal(t, "FieldB value must be equal the field FieldA", v.Errors.One())
 	})
+}
+
+// http://github.com/gookit/validate/issues/301 Regex pipe escape
+func TestIssue_301(t *testing.T) {
+	v := validate.Map(map[string]any{
+		"field": "abc.json",
+		"other": "123",
+	})
+	v.StringRule("field", "required|regex:^[a-zA-Z0-9_.-]+\\.(yaml\\|yml\\|json)$|maxLen:50")
+	v.StringRule("other", "required|regex:^\\d{3}$")
+	assert.True(t, v.Validate())
 }
 
 // http://github.com/gookit/validate/issues/302 The required rule fails for int/uint values when the value is 0.

--- a/rule.go
+++ b/rule.go
@@ -173,7 +173,7 @@ func (v *Validation) StringRule(field, rule string, filterRule ...string) *Valid
 		return v
 	}
 
-	rules := stringSplit(strings.Trim(rule, "|:"), "|")
+	rules := splitRules(strings.Trim(rule, "|:"))
 	for _, validator := range rules {
 		validator = strings.Trim(validator, ":")
 		if validator == "" { // empty

--- a/util.go
+++ b/util.go
@@ -70,6 +70,29 @@ func parseArgString(argStr string) (ss []string) {
 	return stringSplit(argStr, ",")
 }
 
+func splitRules(rules string) (ss []string) {
+	if rules = strings.TrimSpace(rules); len(rules) == 0 {
+		return
+	}
+
+	var (
+		sep = "|"
+		esc = "\\"
+	)
+	for _, val := range strings.Split(rules, sep) {
+		if val = strings.TrimSpace(val); len(val) > 0 {
+			if len(ss) > 0 {
+				if last := ss[len(ss)-1]; strings.HasSuffix(last, esc) {
+					ss[len(ss)-1] = strings.TrimSuffix(last, esc) + sep + val
+					continue
+				}
+			}
+			ss = append(ss, val)
+		}
+	}
+	return
+}
+
 // TODO strutil.Split()
 func stringSplit(str, sep string) (ss []string) {
 	str = strings.TrimSpace(str)


### PR DESCRIPTION
close https://github.com/gookit/validate/issues/301

This PR addresses an issue with parsing validation rules that contain escaped pipe (`|`) characters, particularly relevant for regex rules in the validation library. The key changes involve introducing a new function to correctly split rule strings, updating the rule parsing logic to use this function, and adding a test to verify the fix.

**Rule Parsing Improvements:**

* Added a new `splitRules` function in `util.go` to correctly split rule strings on unescaped pipe (`|`) characters, ensuring that pipes within regex patterns are not treated as rule separators.
* Updated the `StringRule` method in `rule.go` to use the new `splitRules` function instead of a basic string split, improving support for complex rule definitions.

**Testing:**

* Added a new test case `TestIssue_301` in `issues_test.go` to verify that regex rules with escaped pipes are parsed and validated correctly.

**Code Cleanup:**

* Minor reordering of imports in `issues_test.go` for clarity and organization.