### PR TITLE
feat: enhance type conversion fallback in validators

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -1096,7 +1096,11 @@ func Enum(val, enum any) bool {
 
 	v, err := convToBasicType(val)
 	if err != nil {
-		return false
+		// attempt to fall back to string conversion
+		v, err = strutil.ToString(val)
+		if err != nil {
+			return false
+		}
 	}
 
 	// if is string value

--- a/validators_test.go
+++ b/validators_test.go
@@ -677,21 +677,22 @@ func TestLength(t *testing.T) {
 func TestEnumAndNotIn(t *testing.T) {
 	is := assert.New(t)
 	tests := map[any]any{
-		1:   []int{1, 2, 3},
-		2:   []int8{1, 2, 3},
-		3:   []int16{1, 2, 3},
-		4:   []int32{4, 2, 3},
-		5:   []int64{5, 2, 3},
-		6:   []uint{6, 2, 3},
-		7:   []uint8{7, 2, 3},
-		8:   []uint16{8, 2, 3},
-		9:   []uint32{9, 2, 3},
-		10:  []uint64{10, 3},
-		11:  []string{"11", "3"},
-		'a': []int64{97},
-		'b': []rune{'a', 'b'},
-		'c': []byte{'a', 'b', 'c'}, // byte -> uint8
-		"a": []string{"a", "b", "c"},
+		1:          []int{1, 2, 3},
+		2:          []int8{1, 2, 3},
+		3:          []int16{1, 2, 3},
+		4:          []int32{4, 2, 3},
+		5:          []int64{5, 2, 3},
+		6:          []uint{6, 2, 3},
+		7:          []uint8{7, 2, 3},
+		8:          []uint16{8, 2, 3},
+		9:          []uint32{9, 2, 3},
+		10:         []uint64{10, 3},
+		11:         []string{"11", "3"},
+		'a':        []int64{97},
+		'b':        []rune{'a', 'b'},
+		'c':        []byte{'a', 'b', 'c'}, // byte -> uint8
+		"a":        []string{"a", "b", "c"},
+		float64(2): []string{"2", "3"},
 	}
 
 	for val, list := range tests {


### PR DESCRIPTION
When JSON request bodies are decoded into `map[string]interface{}` numeric fields become `float64`. The `enum/in` validation only handled `string`, `int` and `uint` types, causing valid JSON numbers to fail validation unless callers explicitly converted them with Filters. This change keeps the existing `convToBasicType` attempt and, if that fails, falls back to converting the value to a string and re-using the same enum matching logic. It's a small, backward-compatible fix that lets `in:` rules work with numbers coming from JSON without requiring extra Filters.

This update addresses https://github.com/goravel/goravel/issues/816