### PR TITLE
fix(validators): handle pointer fields in RequiredIf (#334)

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -1950,3 +1950,62 @@ func TestIssue_328(t *testing.T) {
 		assert.True(t, v.Validate())
 	})
 }
+
+// https://github.com/gookit/validate/issues/334
+//
+// requiredIf used to skip the check whenever the rule's destination
+// field was a pointer: reflect.ValueOf(*bool).Kind() == reflect.Pointer
+// has no string-to-pointer conversion, so convTypeByBaseKind returned
+// an error, dstVal == wantVal was skipped and the function fell through
+// to "default as True, skip check" -- silently passing validation.
+//
+// And even after the dst-field issue, a *string pointing at "" was
+// counted as present, so the dependent field still validated as set
+// when its underlying string was actually empty.
+func TestIssues_334(t *testing.T) {
+	type Person struct {
+		IsOld      *bool
+		Experience *string `validate:"requiredIf:IsOld,true"`
+	}
+
+	t.Run("pointer to empty string is not present", func(t *testing.T) {
+		isOld := true
+		empty := ""
+		v := validate.Struct(&Person{
+			IsOld:      &isOld,
+			Experience: &empty,
+		})
+		assert.False(t, v.Validate())
+	})
+
+	t.Run("nil pointer is not present", func(t *testing.T) {
+		isOld := true
+		v := validate.Struct(&Person{
+			IsOld: &isOld,
+		})
+		assert.False(t, v.Validate())
+	})
+
+	t.Run("trigger false leaves field optional", func(t *testing.T) {
+		isOld := false
+		v := validate.Struct(&Person{
+			IsOld: &isOld,
+		})
+		assert.True(t, v.Validate())
+	})
+
+	t.Run("nil trigger pointer leaves field optional", func(t *testing.T) {
+		v := validate.Struct(&Person{})
+		assert.True(t, v.Validate())
+	})
+
+	t.Run("pointer to non-empty value satisfies the rule", func(t *testing.T) {
+		isOld := true
+		exp := "10y"
+		v := validate.Struct(&Person{
+			IsOld:      &isOld,
+			Experience: &exp,
+		})
+		assert.True(t, v.Validate())
+	})
+}

--- a/validators.go
+++ b/validators.go
@@ -209,20 +209,53 @@ func (v *Validation) RequiredIf(sourceField string, val any, kvs ...string) bool
 
 	dstField, args := kvs[0], kvs[1:]
 	if dstVal, has := v.Get(dstField); has {
+		// Unwrap pointers in the dst-field value so a *T field is
+		// compared against the literal rule argument by its underlying
+		// kind, not by the reflect.Pointer kind (which has no
+		// string-to-pointer conversion and would silently skip the
+		// rule). A nil pointer is treated as "field absent" so the
+		// optional value is not required.
+		rftDv := reflect.ValueOf(dstVal)
+		for rftDv.Kind() == reflect.Pointer {
+			if rftDv.IsNil() {
+				return true
+			}
+			rftDv = rftDv.Elem()
+			dstVal = rftDv.Interface()
+		}
+
 		// up: only one check value, direct compare value
 		if len(args) == 1 {
-			rftDv := reflect.ValueOf(dstVal)
 			wantVal, err := convTypeByBaseKind(args[0], rftDv.Kind())
 			if err == nil && dstVal == wantVal {
-				return val != nil && !IsEmpty(val) || v.isIgnoreableZeroNumeric(sourceField)
+				return requiredIfValIsPresent(val) || v.isIgnoreableZeroNumeric(sourceField)
 			}
 		} else if Enum(dstVal, args) {
-			return val != nil && !IsEmpty(val) || v.isIgnoreableZeroNumeric(sourceField)
+			return requiredIfValIsPresent(val) || v.isIgnoreableZeroNumeric(sourceField)
 		}
 	}
 
 	// default as True, skip check
 	return true
+}
+
+// requiredIfValIsPresent reports whether the source-field value
+// satisfies a required-style check. A nil pointer counts as absent and
+// a pointer to a zero value (e.g. *string("")) is treated the same as
+// the zero value itself, so requiredIf does not silently pass for
+// pointer-typed empty values.
+func requiredIfValIsPresent(val any) bool {
+	if val == nil {
+		return false
+	}
+	rv := reflect.ValueOf(val)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	return !ValueIsEmpty(rv)
 }
 
 // RequiredUnless field under validation must be present and not empty


### PR DESCRIPTION
Fixes #334.

`Validation.RequiredIf` silently skipped its check whenever either side of the rule was a pointer:

- **Destination field is a pointer.** When the rule references a `*bool`/`*string` field, `reflect.ValueOf(dstVal).Kind()` is `reflect.Pointer`. `convTypeByBaseKind` has no string-to-Pointer conversion, so `dstVal == wantVal` was never evaluated and the function fell through to the `default as True, skip check` branch.
- **Source field is a pointer to a zero value.** `val != nil && !IsEmpty(val)` is `true` for `*string("")` (the pointer is non-nil), so the `must be present and not empty` contract was not enforced.

Unwrap pointers on both sides:

- A nil pointer on the destination side counts as the field being absent: the rule does not trigger and the dependent field stays optional.
- A non-nil pointer on the destination side is compared against the rule argument by its underlying kind, matching how a non-pointer field of the same type is handled today.
- A new `requiredIfValIsPresent` helper applies the same nil-and-zero-via-pointer logic to the source field, so `*string("")` is treated the same as `""`.

The reproducer from the issue:

```go
type Person struct {
    IsOld      *bool
    Experience *string `validate:"requiredIf:IsOld,true"`
}
```

Before this PR, both `{IsOld: &true, Experience: &""}` and `{IsOld: &true}` reported `IsSuccess() == true`. With this PR they correctly report `false`, while `{IsOld: &false}` and `{IsOld: nil}` still pass and `{IsOld: &true, Experience: &"10y"}` still passes.

### Tests

- `TestIssues_334` in `issues_test.go` adds five subtests covering each pointer scenario in the issue. Two of them (`pointer to empty string is not present`, `nil pointer is not present`) fail on the old code with `Result should be False` and pass on the new code; the three previously-passing positive cases continue to pass.
- `go test ./... -count=1 -race` passes locally for the main package and all three locale sub-packages.
- `go vet ./...` and `gofmt -l validators.go issues_test.go` are clean.
